### PR TITLE
Make Fitting use only the bp cache and not the state

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,9 +17,9 @@ TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 
 [compat]
 Graphs = "1.12.0"
-ITensorNetworks = "0.13.3"
+ITensorNetworks = "0.13.9"
 ITensors = "0.9"
 IterTools = "1.10.0"
 KrylovKit = "0.6, 0.7, 0.8"
-NamedGraphs = "0.6.4"
+NamedGraphs = "0.6.8"
 julia = "1.10"

--- a/src/inserter.jl
+++ b/src/inserter.jl
@@ -19,7 +19,7 @@ function inserter!(
   psi = state(problem)
   if region isa ng.NamedEdge
     psi = state(problem)
-    #Is there a world in which this modifies the graph structure, if not setindex also should be used here for efficiency
+    #Is there a world in which this modifies the graph structure, if not preserve_graph also should be used here for efficiency
     psi[Graphs.dst(region)] *= local_tensor
     psi = itn.set_ortho_region(psi, [Graphs.dst(region)])
     set!(problem; state=psi)
@@ -29,16 +29,16 @@ function inserter!(
     indsTe = it.inds(psi[first(region)])
     tags = it.tags(psi, e)
     U, C, _ = it.factorize(local_tensor, indsTe; tags, maxdim, mindim, cutoff)
-    itn.setindex_preserve_graph!(psi, U, first(region))
+    itn.@preserve_graph psi[first(region)] = U
   elseif length(region) == 1
     C = local_tensor
   else
     error("Region of length $(length(region)) not currently supported")
   end
   v = last(region)
-  itn.setindex_preserve_graph!(psi, C, v)
+  itn.@preserve_graph psi[v] = C
   psi = set_orthogonal_region ? itn.set_ortho_region(psi, [v]) : psi
-  normalize && itn.setindex_preserve_graph!(psi, psi[v] / norm(psi[v]), v)
+  normalize && itn.@preserve_graph psi[v] = psi[v] / norm(psi[v])
   set!(problem; state=psi)
   return nothing
 end

--- a/src/inserter.jl
+++ b/src/inserter.jl
@@ -19,6 +19,7 @@ function inserter!(
   psi = state(problem)
   if region isa ng.NamedEdge
     psi = state(problem)
+    #Is there a world in which this modifies the graph structure, if not setindex also should be used here for efficiency
     psi[Graphs.dst(region)] *= local_tensor
     psi = itn.set_ortho_region(psi, [Graphs.dst(region)])
     set!(problem; state=psi)
@@ -28,16 +29,16 @@ function inserter!(
     indsTe = it.inds(psi[first(region)])
     tags = it.tags(psi, e)
     U, C, _ = it.factorize(local_tensor, indsTe; tags, maxdim, mindim, cutoff)
-    psi[first(region)] = U
+    itn.setindex_preserve_graph!(psi, U, first(region))
   elseif length(region) == 1
     C = local_tensor
   else
     error("Region of length $(length(region)) not currently supported")
   end
   v = last(region)
-  psi[v] = C
+  itn.setindex_preserve_graph!(psi, C, v)
   psi = set_orthogonal_region ? itn.set_ortho_region(psi, [v]) : psi
-  normalize && (psi[v] /= norm(psi[v]))
+  normalize && itn.setindex_preserve_graph!(psi, psi[v] / norm(psi[v]), v)
   set!(problem; state=psi)
   return nothing
 end


### PR DESCRIPTION
This PR takes advantage of recent changes in `ITensorNetworks.jl` which makes `AbstractBeliefPropagationCache <:AbstractITensorNetwork` allowing it to be directly gauged and updated.

The `FittingProblem` code now takes advantage of this and there is no need to carry around both the form `<x|y>` and `|y>` in the problem.  Just `<x|y>` is carried around as a `bp_cache` and referred to as the `state` within which `|y>` can be directly gauged and updated.

Additionally the setting of the tensors in `psi` in `inserter!` uses @preserve_graph in places I believe the graph structure is preserved. I left out the `region isa AbstractEdge` because I wasn't sure if there may be intentional graph modification going on in that part?